### PR TITLE
fixed bug hanging of exec processes due to interactive mode prompt

### DIFF
--- a/manifests/namenode/bootstrap.pp
+++ b/manifests/namenode/bootstrap.pp
@@ -10,7 +10,7 @@ class hadoop::namenode::bootstrap {
   # Also wait for the primary name node.
   #
   exec { 'hdfs-bootstrap':
-    command   => 'hdfs namenode -bootstrapStandby && touch /var/lib/hadoop-hdfs/.puppet-hdfs-bootstrapped',
+    command   => 'hdfs namenode -bootstrapStandby -nonInteractive && touch /var/lib/hadoop-hdfs/.puppet-hdfs-bootstrapped',
     creates   => '/var/lib/hadoop-hdfs/.puppet-hdfs-bootstrapped',
     path      => '/bin:/usr/bin',
     user      => 'hdfs',


### PR DESCRIPTION
I figured out this fix partly from doing some debugging and also looking at https://github.com/wikimedia/puppet-cdh.  I would like to apply it to your project as I've been using your puppet module. Without this, I noticed that the module will hang indefinitely if the resource exists due to a interactive prompt and eventually fill up the disk space on the server. You can see this if you try the two exec commands in the terminal by itself when the resource already exists.  I am using hadoop 2.6.