### PR TITLE
fixed journalnode installed if namenode not on same server

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,10 @@
 class hadoop::config {
   contain hadoop::common::config
 
+  if $hadoop::daemon_journalnode {
+    contain hadoop::journalnode::config
+  }
+
   if $hadoop::daemon_namenode {
     contain hadoop::namenode::config
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,6 +3,7 @@
 class hadoop::install {
   contain hadoop::common::install
 
+  if $hadoop::daemon_journalnode { contain hadoop::journalnode::install }
   if $hadoop::daemon_namenode { contain hadoop::namenode::install }
   if $hadoop::daemon_resourcemanager { contain hadoop::resourcemanager::install }
   if $hadoop::daemon_historyserver { contain hadoop::historyserver::install }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,7 @@
 # It ensure the services are running.
 #
 class hadoop::service {
+  if $hadoop::daemon_journalnode { contain hadoop::journalnode::service }
   if $hadoop::daemon_namenode { contain hadoop::namenode::service }
   if $hadoop::daemon_resourcemanager { contain hadoop::resourcemanager::service }
   if $hadoop::daemon_historyserver { contain hadoop::historyserver::service }


### PR DESCRIPTION
fix bug if you have a journalnode on a server without a namenode, journalnode never gets deployed due to assumption it is always collocated with a namenode.